### PR TITLE
Remove initial delay

### DIFF
--- a/lib/EFBoard/EFBoard.cpp
+++ b/lib/EFBoard/EFBoard.cpp
@@ -45,9 +45,10 @@ EFBoardClass::EFBoardClass()
 
 void EFBoardClass::setup() {
     // Setup serial
-    delay(EFBOARD_SERIAL_INIT_DELAY_MS);
+    // If flashing often fails, you can add a safety-backoff delay before running serial which helps with flashing
+    //delay(2000);
     EFBOARD_SERIAL_DEVICE.begin(EFBOARD_SERIAL_BAUD);
-    delay(EFBOARD_SERIAL_INIT_DELAY_MS);
+    delay(50);
 
     LOG("\r\n");
     this->printCredits();

--- a/lib/EFBoard/EFBoard.h
+++ b/lib/EFBoard/EFBoard.h
@@ -30,7 +30,6 @@
 #include "EFBoardPowerState.h"
 
 #define EFBOARD_FIRMWARE_VERSION "v1.1.0"
-#define EFBOARD_SERIAL_INIT_DELAY_MS 1000  //!< Milliseconds to wait before initializing the serial device (prevents flashing if USBSerial is used!)
 #define EFBOARD_SERIAL_DEVICE USBSerial    //!< Serial device to use for logging
 #define EFBOARD_SERIAL_BAUD 115200         //!< Baudrate for the serial device
 

--- a/lib/EFLed/EFLed.cpp
+++ b/lib/EFLed/EFLed.cpp
@@ -62,7 +62,7 @@ void EFLedClass::enablePower() {
     pinMode(EFLED_PIN_5VBOOST_ENABLE, OUTPUT);
     digitalWrite(EFLED_PIN_5VBOOST_ENABLE, HIGH);
     LOG_INFO("(EFLed) Enabled +5V boost converter");
-    delay(10);
+    delay(1);
 }
 
 void EFLedClass::disablePower() {


### PR DESCRIPTION
After tweaking my flashing settings, it now always works. Does it work for you as well? If so, let's remove this annoying delay at the start.

Also tweaked the FastLED delay in the hope to reduce the flicker of the LEDs, but it is still there. =/