### PR TITLE
Merge pio firmware into a single file

### DIFF
--- a/merge-bin.py
+++ b/merge-bin.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+
+# From: https://github.com/platformio/platform-espressif32/issues/1078#issuecomment-2219671743
+
+# Adds PlatformIO post-processing to merge all the ESP flash images into a single image.
+
+import os
+
+Import("env", "projenv")
+
+board_config = env.BoardConfig()
+firmware_bin = "${BUILD_DIR}/${PROGNAME}.bin"
+merged_bin = os.environ.get("MERGED_BIN_PATH", "${BUILD_DIR}/${PROGNAME}-merged.bin")
+
+
+def merge_bin_action(source, target, env):
+    flash_images = [
+        *env.Flatten(env.get("FLASH_EXTRA_IMAGES", [])),
+        "$ESP32_APP_OFFSET",
+        source[0].get_abspath(),
+    ]
+    merge_cmd = " ".join(
+        [
+            '"$PYTHONEXE"',
+            '"$OBJCOPY"',
+            "--chip",
+            board_config.get("build.mcu", "esp32"),
+            "merge_bin",
+            "-o",
+            merged_bin,
+            "--flash_mode",
+            board_config.get("build.flash_mode", "dio"),
+            "--flash_freq",
+            "${__get_board_f_flash(__env__)}",
+            "--flash_size",
+            board_config.get("upload.flash_size", "4MB"),
+            *flash_images,
+        ]
+    )
+    env.Execute(merge_cmd)
+
+
+env.AddCustomTarget(
+    name="mergebin",
+    dependencies=firmware_bin,
+    actions=merge_bin_action,
+    title="Merge binary",
+    description="Build combined image",
+    always_build=True,
+)

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,3 +29,6 @@ build_flags = -std=gnu++2a
 ; upload_flags =
 ; 	--auth=R.A.T.S.
 ; 	--host_port=40042
+
+[env]
+extra_scripts = merge-bin.py


### PR DESCRIPTION
For easier flashing with things like flasher tools, this pio target will merge the compiled firmware files into a single file.

Regular pio compilations split the partitions, bootloader and firmware into seperate files

This is copied from https://github.com/platformio/platform-espressif32/issues/1078#issuecomment-2219671743